### PR TITLE
Various syntax highlighting improvements.

### DIFF
--- a/Symbols/Procedure Index.tmPreferences
+++ b/Symbols/Procedure Index.tmPreferences
@@ -4,7 +4,7 @@
 	<key>name</key>
 	<string>Symbol Index</string>
 	<key>scope</key>
-	<string>source.vhdl meta.block.procedure.specification entity.name.procedure</string>
+	<string>source.vhdl meta.block.procedure.specification entity.name.function.procedure</string>
 	<key>settings</key>
 	<dict>
 		<key>showInIndexedSymbolList</key>

--- a/Symbols/Procedure List.tmPreferences
+++ b/Symbols/Procedure List.tmPreferences
@@ -4,7 +4,7 @@
 	<key>name</key>
 	<string>Symbol List</string>
 	<key>scope</key>
-	<string>source.vhdl meta.block.procedure.specification entity.name.procedure</string>
+	<string>source.vhdl meta.block.procedure.specification entity.name.function.procedure</string>
 	<key>settings</key>
 	<dict>
 		<key>showInSymbolList</key>

--- a/Symbols/Process List.tmPreferences
+++ b/Symbols/Process List.tmPreferences
@@ -4,7 +4,7 @@
 	<key>name</key>
 	<string>Symbol List</string>
 	<key>scope</key>
-	<string>source.vhdl meta.block.process.declaration entity.name.process</string>
+	<string>source.vhdl meta.block.process.declaration entity.name.function.process</string>
 	<key>settings</key>
 	<dict>
 		<key>showInSymbolList</key>

--- a/Syntax/VHDL.sublime-syntax
+++ b/Syntax/VHDL.sublime-syntax
@@ -1866,6 +1866,8 @@ contexts:
         1: punctuation.group.parens.begin.vhdl
       push:
         - meta_scope: meta.group.vhdl
+        - match: ','
+          scope: punctuation.separator.vhdl
         - match: '(\))'
           captures:
             1: punctuation.group.parens.end.vhdl
@@ -2246,6 +2248,8 @@ contexts:
     - include: basic-paren-group
     - include: prototype
     - include: reserved-words
+    - match: ','
+      scope: punctuation.separator.vhdl
     - match: (\))
       captures:
         1: punctuation.group.parens.end.vhdl

--- a/Syntax/VHDL.sublime-syntax
+++ b/Syntax/VHDL.sublime-syntax
@@ -1520,7 +1520,7 @@ contexts:
           captures:
             1: punctuation.terminator.vhdl
           pop: true
-        - match: \b(report|severity)\b
+        - match: (?xi)\b(report|severity)\b
           captures:
             1: keyword.other.vhdl
 
@@ -1728,7 +1728,7 @@ contexts:
         - include: basic-paren-group
         - include: stray-parens
         - include: expression-operators
-        - match: '\b(loop)\b'
+        - match: (?xi)\b(loop)\b
           captures:
             1: keyword.other.vhdl
           set:
@@ -2092,7 +2092,7 @@ contexts:
   constants:
     - match: (?i)\b(true|false)\b
       scope: constant.language.vhdl
-    - match: (?i)\b(note|warning|error|failrue)\b
+    - match: (?i)\b(note|warning|error|failure)\b
       scope: support.constant.std.vhdl
     - match: |-
         (?xi)\b(

--- a/Syntax/VHDL.sublime-syntax
+++ b/Syntax/VHDL.sublime-syntax
@@ -2070,7 +2070,7 @@ contexts:
       scope: keyword.operator.comparison.vhdl
 
   arithmetic-operators:
-    - match: \+|\-|\*|\*\*|/|&|abs
+    - match: \+|\-|\*|\*\*|/|&|\babs
       scope: keyword.operator.arithmetic.vhdl
 
   logical-operators:

--- a/Syntax/VHDL.sublime-syntax
+++ b/Syntax/VHDL.sublime-syntax
@@ -1868,9 +1868,9 @@ contexts:
             1: punctuation.group.parens.end.vhdl
           pop: true
         - include: prototype
+        - include: expression-operators
         - include: reserved-words
         - include: basic-paren-group
-        - include: expression-operators
 
   stray-parens:
     # Should always be included after the basic paren consumer

--- a/Syntax/VHDL.sublime-syntax
+++ b/Syntax/VHDL.sublime-syntax
@@ -1211,7 +1211,7 @@ contexts:
         2: keyword.declaration.vhdl
         4: keyword.other.vhdl
         6: keyword.other.vhdl
-        8: entity.name.label.vhdl
+        8: entity.name.function.process.vhdl
         9: punctuation.terminator.vhdl
       pop: true
     - include: sequential-statements
@@ -2074,7 +2074,7 @@ contexts:
       scope: keyword.operator.comparison.vhdl
 
   arithmetic-operators:
-    - match: \+|\-|\*|\*\*|/|&|\babs
+    - match: \+|\-|\*|\*\*|/|&|\babs\b
       scope: keyword.operator.arithmetic.vhdl
 
   logical-operators:

--- a/Syntax/VHDL.sublime-syntax
+++ b/Syntax/VHDL.sublime-syntax
@@ -412,7 +412,7 @@ contexts:
         - include: library-names
     - match: (?i)\b(use)\b
       captures:
-        1: keyword.other.vhdl
+        1: keyword.control.import.vhdl
       push:
         - meta_scope: meta.statement.use.vhdl
         - match: (;)
@@ -1418,7 +1418,7 @@ contexts:
       captures:
         2: entity.name.label.vhdl
         3: punctuation.separator.vhdl
-        4: keyword.other.vhdl
+        4: keyword.conditional.vhdl
       push:
         - meta_scope: meta.block.generate.conditional.vhdl
         - match: (?i)\b(generate)\b
@@ -1445,7 +1445,7 @@ contexts:
       pop: true
     - match: (?i)\b(else)\s*(generate)\b
       captures:
-        1: keyword.other.vhdl
+        1: keyword.conditional.vhdl
         2: keyword.other.vhdl
     - match: (?i)\b(elsif)\b
       captures:
@@ -1618,7 +1618,7 @@ contexts:
       captures:
         2: entity.name.label.vhdl
         3: punctuation.separator.vhdl
-        4: keyword.other.vhdl
+        4: keyword.conditional.vhdl
       push:
         - meta_scope: meta.block.if.conditional.vhdl
         - match: '(?i)\b(then)\b'
@@ -1634,15 +1634,15 @@ contexts:
     - match: (?i)\b(end)\s+(if)\s*;
       captures:
         1: keyword.declaration.vhdl
-        2: keyword.other.vhdl
+        2: keyword.conditional.vhdl
         3: punctuation.terminator.vhdl
       pop: true
     - match: '(?i)\b(else)\b'
       captures:
-        1: keyword.other.vhdl
+        1: keyword.conditional.vhdl
     - match: '(?i)\b(elsif)\b'
       captures:
-        1: keyword.other.vhdl
+        1: keyword.conditional.vhdl
       set:
         - meta_scope: meta.block.if.conditional.vhdl
         - match: '(?i)\b(then)\b'
@@ -1824,7 +1824,7 @@ contexts:
     # Null statements
     - match: '(?i)\b(null)\b'
       captures:
-        1: keyword.other.vhdl
+        1: constant.language.vhdl
       push:
         - meta_scope: meta.statement.null.vhdl
         - match: (;)
@@ -2086,7 +2086,7 @@ contexts:
 
   constants:
     - match: (?i)\b(true|false)\b
-      scope: support.constant.std.vhdl
+      scope: constant.language.vhdl
     - match: (?i)\b(note|warning|error|failrue)\b
       scope: support.constant.std.vhdl
     - match: |-

--- a/Syntax/VHDL.sublime-syntax
+++ b/Syntax/VHDL.sublime-syntax
@@ -589,7 +589,7 @@ contexts:
         # Also need to match on a lookahead for an unconsumed closing paren
         - match: (?=\))
           pop: true
-        - match: ({{modes}})
+        - match: (\b{{modes}}\b)
           scope: keyword.other.vhdl
     # File declaration
     - match: (?i)(file)\s+({{identifier}}(\s*,\s*{{identifier}})*)\s*(\:)

--- a/Syntax/VHDL.sublime-syntax
+++ b/Syntax/VHDL.sublime-syntax
@@ -1944,11 +1944,13 @@ contexts:
       push:
         - meta_scope: string.quoted.single.vhdl
         - match: '(.)('')'
-          1: constant.character.vhdl
-          2: punctuation.definition.string.end.vhdl
+          captures:
+            1: constant.character.vhdl
+            2: punctuation.definition.string.end.vhdl
           pop: true
         - match: '(.*)'
-          1: invalid.illegal.unclosed-string.vhdl
+          captures:
+            1: invalid.illegal.unclosed-string.vhdl
           pop: true
 
   binary-bit-string-literal:

--- a/Syntax/VHDL.sublime-syntax
+++ b/Syntax/VHDL.sublime-syntax
@@ -893,7 +893,7 @@ contexts:
           captures:
             1: punctuation.terminator.vhdl
           pop: true
-        - match: (?i)(is)
+        - match: (?i)\b(is)\b
           captures:
             1: keyword.declaration.vhdl
           set: procedure-body
@@ -931,7 +931,7 @@ contexts:
           captures:
             1: punctuation.terminator.vhdl
           pop: true
-        - match: (?i)(is)
+        - match: (?i)\b(is)\b
           captures:
             1: keyword.declaration.vhdl
           set: function-body
@@ -1620,7 +1620,7 @@ contexts:
         4: keyword.other.vhdl
       push:
         - meta_scope: meta.block.if.conditional.vhdl
-        - match: '(?i)(then)'
+        - match: '(?i)\b(then)\b'
           captures:
             1: keyword.other.vhdl
           set: seq-if-statements
@@ -1636,15 +1636,15 @@ contexts:
         2: keyword.other.vhdl
         3: punctuation.terminator.vhdl
       pop: true
-    - match: '(?i)(else)'
+    - match: '(?i)\b(else)\b'
       captures:
         1: keyword.other.vhdl
-    - match: '(?i)(elsif)'
+    - match: '(?i)\b(elsif)\b'
       captures:
         1: keyword.other.vhdl
       set:
         - meta_scope: meta.block.if.conditional.vhdl
-        - match: '(?i)(then)'
+        - match: '(?i)\b(then)\b'
           captures:
             1: keyword.other.vhdl
           set: seq-if-statements
@@ -1674,7 +1674,7 @@ contexts:
                 3: entity.name.label.vhdl
                 4: punctuation.terminator.vhdl
               pop: true
-            - match: '(?i)(when)'
+            - match: '(?i)\b(when)\b'
               captures:
                 1: keyword.other.vhdl
               push:

--- a/Syntax/VHDL.sublime-syntax
+++ b/Syntax/VHDL.sublime-syntax
@@ -886,7 +886,7 @@ contexts:
     - match: (?i)(procedure)\s+({{identifier}})
       captures:
         1: storage.type.procedure.vhdl
-        2: entity.name.procedure.vhdl
+        2: entity.name.function.procedure.vhdl
       push:
         - meta_scope: meta.block.procedure.specification.vhdl
         - include: interface-list
@@ -912,7 +912,7 @@ contexts:
           captures:
             1: keyword.declaration.end.vhdl
             2: storage.type.procedure.vhdl
-            3: entity.name.procedure.vhdl
+            3: entity.name.function.procedure.vhdl
             5: punctuation.terminator.vhdl
           pop: true
         - include: sequential-statements
@@ -922,7 +922,7 @@ contexts:
       captures:
         2: keyword.other.vhdl
         3: storage.type.function.vhdl
-        4: entity.name.function.vhdl
+        4: entity.name.function.function.vhdl
       push:
         - meta_scope: meta.block.function.specification.vhdl
         - include: interface-list
@@ -950,7 +950,7 @@ contexts:
           captures:
             1: keyword.declaration.end.vhdl
             2: storage.type.procedure.vhdl
-            3: entity.name.procedure.vhdl
+            3: entity.name.function.function.vhdl
             5: punctuation.terminator.vhdl
           pop: true
         - include: sequential-statements
@@ -1155,12 +1155,12 @@ contexts:
     # Not exactly right for scoping but not too bad I suppose
     - match: (?i)\b(with)\b
       captures:
-        1: keyword.other.vhdl
+        1: keyword.control.vhdl
       push:
         - meta_scope: meta.statement.with-select.vhdl
         - match: (?i)\b(select)\b
           captures:
-            1: keyword.other.vhdl
+            1: keyword.control.vhdl
           pop: true
         - include: expression-operators
         - include: basic-paren-group
@@ -1177,7 +1177,7 @@ contexts:
           ((postponed)\s*)?
           (process)
       captures:
-        2: entity.name.label.vhdl
+        2: entity.name.function.process.vhdl
         3: punctuation.separator.vhdl
         5: keyword.other.vhdl
         6: keyword.other.vhdl
@@ -1471,7 +1471,7 @@ contexts:
       captures:
         2: entity.name.label.vhdl
         3: punctuation.separator.vhdl
-        5: keyword.other.vhdl
+        5: keyword.control.vhdl
       push:
         - meta_scope: meta.block.generate.case.vhdl
         - include: arithmetic-operators
@@ -1494,7 +1494,7 @@ contexts:
               pop: true
             - match: (?i)\b(when)\b
               captures:
-                1: keyword.other.vhdl
+                1: keyword.control.vhdl
               push:
                 - meta_scope: meta.choice.vhdl
                 - match: '(\=>)'
@@ -1659,7 +1659,7 @@ contexts:
       captures:
         2: entity.name.label.vhdl
         3: punctuation.separator.vhdl
-        4: keyword.other.vhdl
+        4: keyword.control.vhdl
       push:
         - meta_scope: meta.block.case.expression.vhdl
         - include: arithmetic-operators
@@ -1677,13 +1677,16 @@ contexts:
               pop: true
             - match: '(?i)\b(when)\b'
               captures:
-                1: keyword.other.vhdl
+                1: keyword.control.vhdl
               push:
                 - meta_scope: meta.choice.vhdl
                 - match: (\=>)
                   captures:
                     1: keyword.operator.assignment.vhdl
                   pop: true
+                - match: (\|)
+                  captures:
+                    1: keyword.operator.logical.vhdl
             - include: sequential-statements
 
   seq-loops:
@@ -1891,12 +1894,12 @@ contexts:
     - match: ({{decchars}})
       captures:
         constant.numeric.decimal.vhdl
-    - match: (to|downto)
+    - match: \b(to|downto)\b
       captures:
         1: keyword.other.vhdl
-    - match: ({{identifier}})
-      captures:
-        1: storage.type.subtype.vhdl
+    # - match: ({{identifier}})
+    #   captures:
+    #     1: storage.type.subtype.vhdl
 
   ###########################################################################
   # Comment Definitions

--- a/Syntax/VHDL.sublime-syntax
+++ b/Syntax/VHDL.sublime-syntax
@@ -1827,7 +1827,7 @@ contexts:
     # Null statements
     - match: '(?i)\b(null)\b'
       captures:
-        1: constant.language.vhdl
+        1: keyword.other.vhdl
       push:
         - meta_scope: meta.statement.null.vhdl
         - match: (;)
@@ -1899,9 +1899,6 @@ contexts:
     - match: \b(to|downto)\b
       captures:
         1: keyword.other.vhdl
-    # - match: ({{identifier}})
-    #   captures:
-    #     1: storage.type.subtype.vhdl
 
   ###########################################################################
   # Comment Definitions

--- a/Syntax/VHDL.sublime-syntax
+++ b/Syntax/VHDL.sublime-syntax
@@ -400,7 +400,7 @@ contexts:
 
   # Combined library and use clause
   libraries:
-    - match: \b(library)\b
+    - match: (?i)\b(library)\b
       captures:
         1: keyword.other.vhdl
       push:
@@ -410,7 +410,7 @@ contexts:
             1: punctuation.terminator.vhdl
           pop: true
         - include: library-names
-    - match: \b(use)\b
+    - match: (?i)\b(use)\b
       captures:
         1: keyword.other.vhdl
       push:
@@ -485,6 +485,7 @@ contexts:
             3: punctuation.terminator.vhdl
           pop: true
         - include: libraries
+        - include: item-configurations
 
   ###########################################################################
   # Interface Definition - This is used for entities and components, but then


### PR DESCRIPTION
I've made some more modifications to the syntax definition file. Most changes relate to more precise scoping to allow detailed color schemes to use all their features, trying to bring things closer to https://www.sublimetext.com/docs/3/scope_naming.html.

Scoping both `function` and `procedure` names as `entity.name.function.x` gives a better highlighting result I think (there is no real equivalent to `procedure` in most languages, `function` is closest). I modified the tmPreference files to adapt the indexing to the new scoping. There might be other unforseen consequences I am not aware of, let me know if more changes are required here.

One thing I'd consider a bugfix: `character-literal` rules were malformed, I've added the 'captures' section.

Marked this as WIP for now, since I still need to clean up some commented code.