### PR TITLE
Make the is after block statement optional

### DIFF
--- a/Syntax/VHDL.sublime-syntax
+++ b/Syntax/VHDL.sublime-syntax
@@ -1680,7 +1680,7 @@ contexts:
         3: punctuation.separator.vhdl
         5: keyword.other.block.block.vhdl
       push:
-        - match: (?i)\b(is)\b
+        - match: (?i)\b(is)?\b
           captures:
             1: keyword.other.block.is.vhdl
           set: block-statement-declarations


### PR DESCRIPTION
This enables syntax highlighting after a block statement without the "is" proceeding it. I haven't found any problems based on the vhd files I had at hand, but it's not thoroughly tested.